### PR TITLE
create_or_update action introduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+v0.1.2
+------
+- create_or_update action added
+- fix no such method default_action
+- recipes folder added as it was required for chef solo
+
 v0.1.1
 ------
 - fixed issue #1

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ hostsfile_entry '1.2.3.4' do
 end
 ```
 
+#### `create_or_update`
+Create a new hosts file entry if not found. If exists appends given hostname to aliases.
+
+```ruby
+hostsfile_entry '1.2.3.4' do
+  hostname 'www.example.com'
+  action :create_or_update
+end
+```
+
 #### `update`
 Updates the given hosts file entry. Does nothing if the entry does not exist.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email 'webops@customink.com'
 license 'All rights reserved'
 description 'Provides an LWRP for managing the /etc/hosts file'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
+version '0.1.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,5 @@
+#
+# Cookbook Name:: hostsfile
+# Recipe:: default
+#
+

--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -18,10 +18,10 @@
 #
 
 # List of all actions supported by the provider
-actions :create, :create_if_missing, :update, :remove
+actions :create, :create_if_missing, :update, :remove, :create_or_update
 
 # Make create the default action
-default_action :create
+#default_action :create
 
 # Required attributes
 attribute :ip_address, :kind_of => String, :name_attribute => true, :required => true


### PR DESCRIPTION
hello,

I have introduced a new action that is mostly required for scenarios I happened to work. Usually, you don't care either you have an entry record or you have not. In the first case you just create it, in the second you append your hostname / domain name to the entry ("making an alias").

So, I have introduced a new method create_or_update.
Also, I have happened to encounter some problems when running your current version:
no such method default_action
and chef_solo was requiring recipes/default.rb for some reason.

Best,
Max
