### PR TITLE
Priority Calculation fixed

### DIFF
--- a/libraries/entry.rb
+++ b/libraries/entry.rb
@@ -42,8 +42,8 @@ class Entry
     def calculate_priority(ip_address)
       return 81 if ip_address == IPAddr.new("127.0.0.1")
       return 80 if IPAddr.new("127.0.0.0/8").include?(ip_address) # local
-      return 60 if ip_address.ipv4? # ipv4
-      return 20 if ip_address.ipv6? # ipv6
+      return 60 if IPAddr.new(ip_address, Socket::AF_UNSPEC).ipv4? # ipv4
+      return 20 if IPAddr.new(ip_address, Socket::AF_UNSPEC).ipv6? # ipv6
       return 00 #
     end
   end


### PR DESCRIPTION
Prio calc failed on IPv6 Loopback "::1", claiming String "::1" has no method "ipv4?"

an ipaddr object has to be used to perform the address family check
