### PR TITLE
Added check to make sure hosts file exists

### DIFF
--- a/libraries/manipulator.rb
+++ b/libraries/manipulator.rb
@@ -23,7 +23,7 @@ class Manipulator
 
   def initialize(node)
     @node = node.to_hash
-    contents = ::File.readlines(hostsfile_path)
+    contents = ::File.exists?(hostsfile_path) ? ::File.readlines(hostsfile_path) : []
 
     @entries = contents.collect do |line|
       Entry.parse(line) unless line.strip.nil? || line.strip.empty?


### PR DESCRIPTION
This adds a check to make sure that the file derived from hostsfile_path actually exists before trying to read. (If someone deletes the hosts file, the readlines call fails and the chef run stops).
