### PR TITLE
Fix require when $LOADPATH isn't set correctly

### DIFF
--- a/libraries/manipulator.rb
+++ b/libraries/manipulator.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'entry'
+require_relative 'entry'
 
 require 'chef/application'
 require 'digest/sha2'


### PR DESCRIPTION
I was having issues getting ruby to find the entry.rb with chef 11.4.4 on knife solo. Apparently `$LOADPATH` doesn't always contain the libraries/ directory, so `require_relative` is the best way to do it.
