### PR TITLE
don't add calculated priorities to /etc/hosts

### DIFF
--- a/libraries/entry.rb
+++ b/libraries/entry.rb
@@ -161,6 +161,14 @@ class Entry
     ].join(', ') + '>'
   end
 
+  # Returns true if priority is calculated
+  #
+  # @return [Boolean]
+  #   true if priority is calculated and false otherwise
+  def calculated_priority?
+    @calculated_priority
+  end
+
   private
 
     # Calculates the relative priority of this entry.

--- a/libraries/manipulator.rb
+++ b/libraries/manipulator.rb
@@ -230,7 +230,7 @@ class Manipulator
           :hostname   => entry.hostname,
           :aliases    => entry.aliases,
           :comment    => entry.comment,
-          :priority   => entry.priority,
+          :priority   => !entry.calculated_priority? && entry.priority,
         )
       end
     end


### PR DESCRIPTION
Currently calculated priorities are added to `/etc/hosts` to lines like `127.0.0.1 localhost`.

This commit fixes this.
