### PR TITLE
remove trailing commas at the end of hash

### DIFF
--- a/libraries/manipulator.rb
+++ b/libraries/manipulator.rb
@@ -74,7 +74,7 @@ class Manipulator
       :hostname   => options[:hostname],
       :aliases    => options[:aliases],
       :comment    => options[:comment],
-      :priority   => options[:priority],
+      :priority   => options[:priority]
     )
   end
 
@@ -230,7 +230,7 @@ class Manipulator
           :hostname   => entry.hostname,
           :aliases    => entry.aliases,
           :comment    => entry.comment,
-          :priority   => !entry.calculated_priority? && entry.priority,
+          :priority   => !entry.calculated_priority? && entry.priority
         )
       end
     end


### PR DESCRIPTION
this restores compatibility with ruby 1.8
