### PR TITLE
If IP changes by hostname stays the same 2 entries are created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ would yield an /etc/hosts file like this:
     2.3.4.5          www.example.com
 
 #### `create`
-Creates a new hosts file entry. If an entry already exists, it will be overwritten by this one.
+Creates a new hosts file entry. If an entry with this same ip already exists, it will be overwritten by this one.
 
 ```ruby
 hostsfile_entry '1.2.3.4' do
@@ -84,6 +84,27 @@ end
 This will create an entry like this:
 
     1.2.3.4          example.com
+
+#### `create_by_host`
+Creates a new hosts file entry. If an entry with this same hostname but different ip already exists, the ip will be overwritten by this one.
+
+```ruby
+hostsfile_entry '5.5.5.5' do
+  hostname  'example.com'
+  action    :create_by_host
+end
+```
+
+If an entry like this already exists:
+
+    1.2.3.4          example.com
+
+It will be overwritten as :
+
+    5.5.5.5          example.com
+
+If absent, it will be created.
+
 
 #### `create_if_missing`
 Create a new hosts file entry, only if one does not already exist for the given IP address. If one exists, this does nothing.

--- a/libraries/manipulator.rb
+++ b/libraries/manipulator.rb
@@ -69,13 +69,13 @@ class Manipulator
   # @option options [Fixnum] :priority
   #   the relative priority of this entry (compared to others)
   def add(options = {})
-    @entries << Entry.new(
+    @entries << Entry.new({
       :ip_address => options[:ip_address],
       :hostname   => options[:hostname],
       :aliases    => options[:aliases],
       :comment    => options[:comment],
       :priority   => options[:priority],
-    )
+    })
   end
 
   # Update an existing entry. This method will do nothing if the entry
@@ -85,6 +85,19 @@ class Manipulator
   def update(options = {})
     if entry = find_entry_by_ip_address(options[:ip_address])
       entry.hostname  = options[:hostname]
+      entry.aliases   = options[:aliases]
+      entry.comment   = options[:comment]
+      entry.priority  = options[:priority]
+    end
+  end
+
+  # Update an existing entry. This method will do nothing if the entry
+  # does not exist.
+  #
+  # @param (see #add)
+  def update_by_hostname(options = {})
+    if entry = find_entry_by_hostname(options[:hostname])
+      entry.ip_address = options[:ip_address]
       entry.aliases   = options[:aliases]
       entry.comment   = options[:comment]
       entry.priority  = options[:priority]
@@ -170,6 +183,18 @@ class Manipulator
     end
   end
 
+  # Find an entry by the given IP Address.
+  #
+  # @param [String] ip_address
+  #   the IP Address of the entry to detect
+  # @return [Entry, nil]
+  #   the corresponding entry object, or nil if it does not exist
+  def find_entry_by_hostname(hostname)
+    @entries.detect do |entry|
+      !entry.hostname.nil? && entry.hostname == hostname
+    end
+  end
+
   private
 
     # The path to the current hostsfile.
@@ -225,13 +250,13 @@ class Manipulator
         entry = Entry.parse(line)
         next if entry.nil?
 
-        append(
+        append({
           :ip_address => entry.ip_address,
           :hostname   => entry.hostname,
           :aliases    => entry.aliases,
           :comment    => entry.comment,
           :priority   => !entry.calculated_priority? && entry.priority,
-        )
+        })
       end
     end
 end

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -32,6 +32,29 @@ action :create do
   new_resource.updated_by_last_action(true) if hostsfile.save!
 end
 
+action :create_by_host do
+  if hostsfile.find_entry_by_hostname(new_resource.hostname).nil?
+    hostsfile.add(
+      :ip_address => new_resource.ip_address,
+      :hostname => new_resource.hostname,
+      :aliases => new_resource.aliases,
+      :comment => new_resource.comment,
+      :priority => new_resource.priority
+    )
+    new_resource.updated_by_last_action(true) if hostsfile.save!
+  else
+    hostsfile.update_by_hostname(
+      :ip_address => new_resource.ip_address,
+      :hostname => new_resource.hostname,
+      :aliases => new_resource.aliases,
+      :comment => new_resource.comment,
+      :priority => new_resource.priority
+    )
+    new_resource.updated_by_last_action(true) if hostsfile.save!
+  end
+end
+
+
 # Create a new hosts file entry, only if one does not already exist for
 # the given IP address. If one exists, this does nothing.
 action :create_if_missing do

--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -19,7 +19,7 @@
 #
 
 # List of all actions supported by the provider
-actions :create, :create_if_missing, :append, :update, :remove
+actions :create, :create_if_missing, :append, :update, :remove, :create_by_host
 
 # Make create the default action
 default_action :create


### PR DESCRIPTION
add the create_by_host action which will change the IP, but keep the hostname constant.

Useful in the case where a machine may be replaced with a new IP, but you want to update the hostfile entry, not create a new one.

Docs give example 
https://github.com/shokunin/hostsfile#create_by_host
