### PR TITLE
Allow to specify a custom path for the hostsfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Have any other cookbooks *depend* on hostsfile by editing editing the `metadata.
 depends 'hostsfile'
 ```
 
+Note that you can specify a custom path to your hosts file in the `['hostsfile']['path']` node attribute. Otherwise, it defaults to sensible paths depending on your OS.
+
 
 Priority
 --------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,22 @@
+#
+# Author:: Seth Vargo <sethvargo@gmail.com>
+# Cookbook:: hostsfile
+# Attribute:: default
+#
+# Copyright 2012-2013, Seth Vargo
+# Copyright 2012, CustomInk, LCC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['hostsfile']['path'] = nil

--- a/libraries/manipulator.rb
+++ b/libraries/manipulator.rb
@@ -182,13 +182,15 @@ class Manipulator
     #
     # @return [String]
     #   the full path to the hostsfile, depending on the operating system
+    #   can also be overriden in the node attributes
     def hostsfile_path
-      @hostsfile_path ||= case node['platform_family']
-                          when 'windows'
-                            "#{node['kernel']['os_info']['system_directory']}\\drivers\\etc\\hosts"
-                          else
-                            '/etc/hosts'
-                          end
+      return @hostsfile_path if @hostsfile_path
+      @hostsfile_path = node['hostsfile']['path'] || case node['platform_family']
+                                                     when 'windows'
+                                                       "#{node['kernel']['os_info']['system_directory']}\\drivers\\etc\\hosts"
+                                                     else
+                                                       '/etc/hosts'
+                                                     end
     end
 
     # The current sha of the system hostsfile.


### PR DESCRIPTION
We happen to be running a custom Linux distro on some boxes, where the hosts file, for (debatable) legacy reason, is not /etc/hosts. I'd like to be able to override the default OS path with a node attribute.

Thanks!
