### PR TITLE
update require_chef_omnibus avoid chef-zero error

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 11.8.0
+  require_chef_omnibus: 11.16.4
 
 platforms:
   - name: ubuntu-12.04


### PR DESCRIPTION
when running kitchen test with require_chef_omnibus: 11.8.0, chef-zero raises Errno::ENAMETOOLONG: File name too long.
updating  require_chef_omnibus to 11.16.4 fixes this issue.

```
[2014-12-04T04:22:24+00:00] INFO: HTTP Request Returned 404 Not Found: Object not found: /reports/nodes/append-ubuntu-1204/runs       
resolving cookbooks for run list: ["fake::append"]       
[2014-12-04T04:22:24+00:00] ERROR: #<Errno::ENAMETOOLONG: File name too long - {"name":"fake","description":"A fabulous new cookbook","long_description":"","maintainer":"YOUR_COMPANY_NAME","maintainer_email":"YOUR_EMAIL","license":"none","platforms":{},"dependencies":{"hostsfile":">= 0.0.0"},"recommendations":{},"suggestions":{},"conflicting":{},"providing":{},"replacing":{},"attributes":{},"groupings":{},"recipes":{},"version":"1.0.0"}>
```
