### PR TITLE
support Serverspec v2

### DIFF
--- a/test/integration/append/serverspec/append_spec.rb
+++ b/test/integration/append/serverspec/append_spec.rb
@@ -1,5 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
+set :backend, :exec
 
 describe 'hostsfile_entry - append' do
   it 'creates a new entry if one does not already exist' do

--- a/test/integration/append_existing/serverspec/append_existing_spec.rb
+++ b/test/integration/append_existing/serverspec/append_existing_spec.rb
@@ -1,5 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
+set :backend, :exec
 
 describe 'hostsfile_entry - append_existing' do
   it 'creates a new entry if one does not already exist' do

--- a/test/integration/create/serverspec/create_spec.rb
+++ b/test/integration/create/serverspec/create_spec.rb
@@ -1,5 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
+set :backend, :exec
 
 describe 'hostsfile_entry - create' do
   it 'creates a new entry' do

--- a/test/integration/create_if_missing/serverspec/create_if_missing_spec.rb
+++ b/test/integration/create_if_missing/serverspec/create_if_missing_spec.rb
@@ -1,5 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
+set :backend, :exec
 
 describe 'hostsfile_entry - create_if_missing' do
   it 'creates a new entry if one is missing' do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,5 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
+set :backend, :exec
 
 describe 'hostsfile_entry - default' do
   it 'creates a new entry' do

--- a/test/integration/options/serverspec/options_spec.rb
+++ b/test/integration/options/serverspec/options_spec.rb
@@ -1,5 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
+set :backend, :exec
 
 describe 'hostsfile_entry - options' do
   it 'appends all options to the entry' do

--- a/test/integration/unique/serverspec/unique_spec.rb
+++ b/test/integration/unique/serverspec/unique_spec.rb
@@ -1,5 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
+set :backend, :exec
 
 describe 'hostsfile_entry - unique' do
   it 'removes existing hostnames when unique is specified' do


### PR DESCRIPTION
http://serverspec.org/changes-of-v2.html

> In version 2, you can specify backend type with set :backend, :type and auto detection is default behavior, so don't include SpecInfra::Helper::_backend_type_ and Specinfra::Helper::DetectOS. 
