### PR TITLE
Add ipv6 ::1 to tests and priorities, with README priority updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ hostsfile Cookbook CHANGELOG
 =======================
 This file is used to list changes made in each version of the hostsfile cookbook.
 
+v2.4.5 (pending release)
+-------------------
+- Expand priority documentation in README
+- Add ::1 loopback to test cases and priority settings
 
 v2.4.5 (2014-06-24)
 -------------------

--- a/README.md
+++ b/README.md
@@ -197,9 +197,11 @@ Priority
 --------
 Priority is a relatively new addition to the cookbook. It gives you the ability to (somewhat) specify the relative order of entries. By default, the priority is calculated for you as follows:
 
-1. Local, loopback
-2. IPV4
-3. IPV6
+82. 127.0.0.1
+81. ::1
+80. 127.0.0.0/8
+60. IPV4
+20. IPV6
 
 However, you can override it using the `priority` option.
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Priority is a relatively new addition to the cookbook. It gives you the ability 
 80. 127.0.0.0/8
 60. IPV4
 20. IPV6
+00. default
 
 However, you can override it using the `priority` option.
 

--- a/libraries/entry.rb
+++ b/libraries/entry.rb
@@ -162,7 +162,8 @@ class Entry
   def calculated_priority
     @calculated_priority = true
 
-    return 81 if ip_address == IPAddr.new('127.0.0.1')
+    return 82 if ip_address == IPAddr.new('127.0.0.1')
+    return 81 if ip_address == IPAddr.new('::1')
     return 80 if IPAddr.new('127.0.0.0/8').include?(ip_address) # local
     return 60 if ip_address.ipv4? # ipv4
     return 20 if ip_address.ipv6? # ipv6

--- a/spec/unit/manipulator_spec.rb
+++ b/spec/unit/manipulator_spec.rb
@@ -8,6 +8,7 @@ describe Manipulator do
   let(:lines) do
     [
       "127.0.0.1  localhost",
+      "::1  localhost6",
       "1.2.3.4  example.com",
       "4.5.6.7  foo.example.com"
     ]
@@ -16,6 +17,7 @@ describe Manipulator do
   let(:entries) do
     [
       Entry.new(ip_address: '127.0.0.1', hostname: 'localhost',       to_line: '127.0.0.1  localhost',     priority: 10),
+      Entry.new(ip_address: '::1', hostname: 'localhost6',       to_line: '::1  localhost6',     priority: 11),
       Entry.new(ip_address: '1.2.3.4',   hostname: 'example.com',     to_line: '1.2.3.4  example.com',     priority: 20),
       Entry.new(ip_address: '4.5.6.7',   hostname: 'foo.example.com', to_line: '4.5.6.7  foo.example.com', priority: 30)
     ]
@@ -249,8 +251,9 @@ describe Manipulator do
   describe '#find_entry_by_ip_address' do
     it 'finds the associated entry' do
       expect(manipulator.find_entry_by_ip_address('127.0.0.1')).to eq(entries[0])
-      expect(manipulator.find_entry_by_ip_address('1.2.3.4')).to eq(entries[1])
-      expect(manipulator.find_entry_by_ip_address('4.5.6.7')).to eq(entries[2])
+      expect(manipulator.find_entry_by_ip_address('::1')).to eq(entries[1])
+      expect(manipulator.find_entry_by_ip_address('1.2.3.4')).to eq(entries[2])
+      expect(manipulator.find_entry_by_ip_address('4.5.6.7')).to eq(entries[3])
     end
 
     it 'returns nil if the entry does not exist' do


### PR DESCRIPTION
Addresses https://github.com/customink-webops/hostsfile/issues/62.

The hostsfile recipes do not currently detect, or prioritize, IPv6 loopback addresses. There's also not enough range in priority between '127.0.0.1' and '127.0.0.0/8' to put the ::1 loopback where it would normally go. This is especially problematic in various cases where the '::1' might wind up listed before other loopback addresses and the host is not configuredto use IPv6.

I've also updated the README.md to reflect this, and to list actual priority levels with their numerical values. It was particularly confusing when the README listed them as priority "1,2,3,4" in ascending order, and they were actually processed as "81,80,60,40,20" in descending order.