### PR TITLE
Feature/default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ This will remove the entry for `1.2.3.4`.
 
 Usage
 -----
+### Install
 If you're using [Berkshelf](http://berkshelf.com/), just add `hostsfile` to your `Berksfile`:
 
 ```ruby
@@ -166,6 +167,7 @@ Otherwise, install the cookbook from the community site:
 
     knife cookbook site install hostsfile
 
+### Inside own cookbook usage
 Have any other cookbooks *depend* on hostsfile by editing editing the `metadata.rb` for your cookbook.
 
 ```ruby
@@ -174,6 +176,38 @@ depends 'hostsfile'
 ```
 
 Note that you can specify a custom path to your hosts file in the `['hostsfile']['path']` node attribute. Otherwise, it defaults to sensible paths depending on your OS.
+
+### Out-of-the-box usage with role's overriden attributes
+You can specify hostsfile entries directly in your roles
+```ruby
+    # roles/example_role.rb file
+    name "example_role"
+    run_list(
+      "recipe[hostsfile]",
+    )
+    override_attributes(
+      "hostsfile" => {
+        "entries" => [
+          {
+            "hostname" => "www.example.com",
+            "ip_address" => "10.0.0.21",
+            "aliases" => [ "www" ]
+          },
+          {
+            "hostname" => "api.example.com",
+            "ip_address" => "10.0.0.22",
+            "aliases" => [ "api" ]
+          }
+        ]
+      }
+    )
+```
+This will produce entries like that:
+
+    10.0.0.21      www.example.com www
+    10.0.0.22      api.example.com api
+
+Deafult recipe uses "create" action, so all already defined entries with the same hostnames will be overwritten. All other entries won't be affected.
 
 ### Testing
 If you are using [ChefSpec](https://github.com/sethvargo/chefspec) to unit test a cookbook that implements the `hostsfile_entry` LWRP, this cookbook packages customer matchers that you can use in your unit tests:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,5 @@
 #
 
 default['hostsfile']['path'] = nil
+
+default['hostsfile']['entries'] = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,9 @@
+entries = node['hostsfile']['entries']
+
+entries.each do |entry|
+  hostsfile_entry entry['ip_address'] do
+    hostname  entry['hostname']
+    aliases   entry['aliases']
+    action    :create
+  end
+end


### PR DESCRIPTION
This feature branch adds default recipe. It can be useful for those people who follow strategy of reusing already existent code as much as possible, because writing and supporting own cookbooks in large chef infrastructure is expensive.