### PR TITLE
added support for CRLF on windows to avoid max aliases per line issue

### DIFF
--- a/libraries/manipulator.rb
+++ b/libraries/manipulator.rb
@@ -217,7 +217,14 @@ class Manipulator
     entries = hostsfile_header
     entries += unique_entries.map(&:to_line)
     entries << ''
-    entries.join("\n")
+    # windows has a limit of 9 host aliases per line, so without proper line
+    # endings, additional host entries wind up being ignored
+    case node['platform_family']
+      when 'windows'
+        entries.join("\r\n")
+      else
+        entries.join("\n")
+      end
   end
 
   # The current sha of the system hostsfile.


### PR DESCRIPTION
I've been using this for a while, and even though on Windows when you view the hosts file everything appears to be on one line, it has been working.  I recently noticed that if you have a lot of host aliases on the same machine the ones at the end aren't honored, and then discovered that there is a limit on Windows of 9 aliases per line.  So this small fix uses the environment specific newline terminator, so "\r\n" for Windows and "\n" for all other environments.