### PR TITLE
'File.exists?' is deprecated so switch to 'exist?' in specs

### DIFF
--- a/spec/unit/manipulator_spec.rb
+++ b/spec/unit/manipulator_spec.rb
@@ -27,7 +27,7 @@ describe HostsFile::Manipulator do
   let(:header) { manipulator.hostsfile_header }
 
   before do
-    allow(File).to receive(:exists?).and_return(true)
+    allow(File).to receive(:exist?).and_return(true)
     allow(File).to receive(:readlines).and_return(lines)
     manipulator.instance_variable_set(:@entries, entries)
   end
@@ -39,7 +39,7 @@ describe HostsFile::Manipulator do
     end
 
     it 'raises a fatal error if the hostsfile does not exist' do
-      allow(File).to receive(:exists?).and_return(false)
+      allow(File).to receive(:exist?).and_return(false)
       expect { HostsFile::Manipulator.new(node) }.to raise_error(RuntimeError)
     end
 
@@ -264,7 +264,7 @@ describe HostsFile::Manipulator do
   describe '#hostsfile_path' do
     before do
       manipulator.class.send(:public, :hostsfile_path)
-      allow(File).to receive(:exists?).and_return(true)
+      allow(File).to receive(:exist?).and_return(true)
     end
 
     context 'with no node attribute specified' do


### PR DESCRIPTION
My understanding is that this is where some spec failures were coming from.