### PR TITLE
Default recipe for attribute-driven configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@
 
 default['hostsfile']['path'] = nil
 
-# Weather to create an entry for the FQDN in /etc/hosts
+# Whether to create an entry for the FQDN in /etc/hosts
 default['hostsfile']['add_fqdn'] = false
 
 # Entries to be added to /etc/hosts defined in the form:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@
 #
 # Copyright:: 2012-2013, Seth Vargo
 # Copyright:: 2012, CustomInk, LCC
+# Copyright:: 2017, Workday, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,3 +21,17 @@
 #
 
 default['hostsfile']['path'] = nil
+
+# Weather to create an entry for the FQDN in /etc/hosts
+default['hostsfile']['add_fqdn'] = false
+
+# Entries to be added to /etc/hosts defined in the form:
+#
+# '1.2.3.4' => {
+#   hostname: 'test.example.com',
+#   unique:   true/false,
+#   ...
+# }
+#
+# The entries can use any attribute supported by the hostsfile_entry resource
+default['hostsfile']['entries'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,34 @@
+#
+# rubocop:disable AsciiComments
+#
+# Author:: Bogdan Katyński <bogdan.katynski@workday.com>
+# Cookbook Name:: hostsfile
+# Recipe:: default
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# rubocop:enable AsciiComments
+
+# Create a mapping for the FQDN
+hostsfile_entry node['ipaddress'] do
+  hostname  node['fqdn']
+  action    :create
+  unique    true
+  only_if   { node['hostsfile']['add_fqdn'] }
+end
+
+node['hostsfile']['entries'].each do |ip, attrs|
+  hostsfile_entry ip do
+    attrs.each { |a, v| send(a, v) }
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,4 @@
 #
-# rubocop:disable AsciiComments
-#
 # Author:: Bogdan Katyński <bogdan.katynski@workday.com>
 # Cookbook Name:: hostsfile
 # Recipe:: default
@@ -17,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# rubocop:enable AsciiComments
 
 # Create a mapping for the FQDN
 hostsfile_entry node['ipaddress'] do

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,6 +1,4 @@
 #
-# rubocop:disable AsciiComments
-#
 # Author:: Bogdan Katyński <bogdan.katynski@gmail.com>
 # Cookbook Name:: hostsfile
 # Spec:: default
@@ -19,8 +17,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# rubocop:enable AsciiComments
 #
 
 require 'spec_helper'
@@ -53,13 +49,13 @@ describe 'hostsfile::default' do
       {
         '1.2.3.4' => {
           hostname: 'host1.some.test.domain',
-          unique: false
+          unique: false,
         },
         '2.3.4.5' => {
           hostname: 'host2.some.test.domain',
           unique: true,
-          aliases: %w(alias1.some.test.domain alias2.some.test.domain)
-        }
+          aliases: %w(alias1.some.test.domain alias2.some.test.domain),
+        },
       }
     end
     let(:runner) do
@@ -79,8 +75,8 @@ describe 'hostsfile::default' do
         {
           '1.2.3.4' => {
             hostname: 'host1.some.test.domain',
-            action: :unsupported_action
-          }
+            action: :unsupported_action,
+          },
         }
       end
 

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,0 +1,92 @@
+#
+# rubocop:disable AsciiComments
+#
+# Author:: Bogdan Katyński <bogdan.katynski@gmail.com>
+# Cookbook Name:: hostsfile
+# Spec:: default
+#
+# Copyright:: 2017, Bogdan Katyński
+# Copyright:: 2017, Workday, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# rubocop:enable AsciiComments
+#
+
+require 'spec_helper'
+
+describe 'hostsfile::default' do
+  let(:runner) { ChefSpec::SoloRunner.new }
+  let(:node) { chef_run.node }
+  let(:chef_run) { runner.converge(described_recipe) }
+
+  context 'When all attributes are default' do
+    it 'does not update /etc/hosts' do
+      expect(chef_run).not_to create_hostsfile_entry(node['ipaddress'])
+    end
+  end
+
+  context 'When add_fqdn attr is true' do
+    let(:runner) do
+      ChefSpec::SoloRunner.new do |node|
+        node.override['hostsfile']['add_fqdn'] = true
+      end
+    end
+    it 'creates a mapping for the fqdn in /etc/hosts' do
+      expect(chef_run).to create_hostsfile_entry(node['ipaddress'])
+        .with(unique: true, hostname: node['fqdn'])
+    end
+  end
+
+  context 'when there are hostsfile entries in the node attribute' do
+    let(:entries) do
+      {
+        '1.2.3.4' => {
+          hostname: 'host1.some.test.domain',
+          unique: false
+        },
+        '2.3.4.5' => {
+          hostname: 'host2.some.test.domain',
+          unique: true,
+          aliases: %w(alias1.some.test.domain alias2.some.test.domain)
+        }
+      }
+    end
+    let(:runner) do
+      ChefSpec::SoloRunner.new do |node|
+        node.override['hostsfile']['entries'] = entries
+      end
+    end
+
+    it 'creates mappings for all entries in /etc/hosts' do
+      entries.each do |ip, attrs|
+        expect(chef_run).to create_hostsfile_entry(ip).with(attrs)
+      end
+    end
+
+    context 'when there is a hostfile entry with an unsupported attribute' do
+      let(:entries) do
+        {
+          '1.2.3.4' => {
+            hostname: 'host1.some.test.domain',
+            action: :unsupported_action
+          }
+        }
+      end
+
+      it 'raises an error' do
+        expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the default recipe which creates
hosts file entries based on a node attribute.

This new functionality can simplify the use of
the hosts file cookbook in some cases because
it makes managing the hosts file possible with
just data.

Issue: #85